### PR TITLE
feat: Sort deny reasons in error message

### DIFF
--- a/_examples/basic/gen/toucan/authorizers.go
+++ b/_examples/basic/gen/toucan/authorizers.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+
 	models "github.com/endigma/toucan/_examples/basic/models"
 	conc "github.com/sourcegraph/conc"
-	"strings"
 )
 
 type Authorizer interface {
@@ -141,6 +143,8 @@ func (a authorizer) Authorize(ctx context.Context, actor *models.User, permissio
 		}
 		denyReasons = append(denyReasons, fmt.Sprintf("%s", result.source))
 	}
+
+	sort.Sort(sort.StringSlice(denyReasons))
 
 	return fmt.Errorf("authorize %s: %w: missing %s", permission, Deny, strings.Join(denyReasons, ", "))
 }

--- a/codegen/authorizer.go
+++ b/codegen/authorizer.go
@@ -168,6 +168,8 @@ func (gen *Generator) generateAuthorizerRoot(group *Group) {
 			),
 		),
 		Line(),
+		Qual("sort", "Strings").Call(Qual("sort", "StringSlice").Call(Id("denyReasons"))),
+		Line(),
 		Return(Qual("fmt", "Errorf").Call(
 			Lit("authorize %s: %w: missing %s"),
 			Id("permission"),


### PR DESCRIPTION
This will hopefully make deny reasons stable. As we race results and short-circuit for allows, those will stay unpredictable. However for test cases the vast majority will only care about deny reasons.

(draft since I haven't tested this fixes the issue yet)